### PR TITLE
Add database and management script

### DIFF
--- a/database.json
+++ b/database.json
@@ -1,0 +1,16 @@
+{
+  "entries": [
+    {
+      "name": "Alpha Centauri",
+      "description": "Nearest star system to Sol."
+    },
+    {
+      "name": "Galactic Archives",
+      "description": "Central repository of historical records."
+    },
+    {
+      "name": "Exoplanet Survey",
+      "description": "Catalog of habitable worlds discovered to date."
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -25,20 +25,18 @@
     <input type="text" id="search" placeholder="Search the archives..." />
     <div id="results"></div>
     <script>
-      const data = [
-        { name: 'Alpha Centauri', description: 'Nearest star system to Sol.' },
-        {
-          name: 'Galactic Archives',
-          description: 'Central repository of historical records.'
-        },
-        {
-          name: 'Exoplanet Survey',
-          description: 'Catalog of habitable worlds discovered to date.'
-        }
-      ];
+      let data = [];
+      const resultsDiv = document.getElementById('results');
+      fetch('database.json')
+        .then(res => res.json())
+        .then(json => {
+          data = json.entries || [];
+        })
+        .catch(err => {
+          resultsDiv.innerHTML = '<p>Error loading database.</p>';
+        });
 
       const searchInput = document.getElementById('search');
-      const resultsDiv = document.getElementById('results');
 
       function renderResults(results) {
         if (results.length === 0) {

--- a/manage.js
+++ b/manage.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+
+const DB_FILE = path.join(__dirname, 'database.json');
+
+function loadDB() {
+  if (!fs.existsSync(DB_FILE)) {
+    return { entries: [] };
+  }
+  return JSON.parse(fs.readFileSync(DB_FILE, 'utf8'));
+}
+
+function saveDB(db) {
+  fs.writeFileSync(DB_FILE, JSON.stringify(db, null, 2));
+}
+
+const [,, cmd, ...args] = process.argv;
+
+switch (cmd) {
+  case 'mkdir': {
+    const dir = args[0];
+    if (!dir) {
+      console.error('Usage: node manage.js mkdir <directory>');
+      process.exit(1);
+    }
+    fs.mkdirSync(dir, { recursive: true });
+    console.log(`Created directory: ${dir}`);
+    break;
+  }
+  case 'add-entry': {
+    const name = args[0];
+    const description = args[1];
+    if (!name || !description) {
+      console.error('Usage: node manage.js add-entry <name> <description>');
+      process.exit(1);
+    }
+    const db = loadDB();
+    db.entries.push({ name, description });
+    saveDB(db);
+    console.log('Entry added.');
+    break;
+  }
+  default:
+    console.log('Usage:');
+    console.log('  node manage.js mkdir <directory>');
+    console.log('  node manage.js add-entry <name> <description>');
+}


### PR DESCRIPTION
## Summary
- switch HTML search to use a JSON database
- add JSON database file to repo
- provide `manage.js` CLI script to create directories and add entries

## Testing
- `node manage.js add-entry "Test" "Test entry" && node manage.js mkdir dir1`


------
https://chatgpt.com/codex/tasks/task_e_6847fd76c6248331b262b4784881aca0