### PR TITLE
Improve side panel display

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
         color: #0f0;
         font-family: monospace;
         padding: 20px;
+        margin-right: 320px;
       }
       input {
         background: #000;
@@ -35,8 +36,15 @@
         color: #0f0;
         border-left: 1px solid #0f0;
         padding: 10px;
-        display: none;
+        display: block;
         overflow-y: auto;
+      }
+      @keyframes fadeInText {
+        from { opacity: 0; }
+        to { opacity: 1; }
+      }
+      #side-content.fade-in {
+        animation: fadeInText 0.5s ease;
       }
       #side-panel h3 {
         margin-top: 0;
@@ -56,7 +64,6 @@
     </div>
     <ul id="file-list"></ul>
     <div id="side-panel">
-      <button id="close-panel">Close</button>
       <div id="side-content"></div>
     </div>
     <script>
@@ -70,7 +77,6 @@
       const upFolderBtn = document.getElementById('up-folder');
       const sidePanel = document.getElementById('side-panel');
       const sideContent = document.getElementById('side-content');
-      const closePanelBtn = document.getElementById('close-panel');
 
       function escapeHtml(str) {
         return str
@@ -97,9 +103,6 @@
         return html;
       }
 
-      closePanelBtn.addEventListener('click', () => {
-        sidePanel.style.display = 'none';
-      });
 
       function saveData() {
         localStorage.setItem('fsData', JSON.stringify(fsData));
@@ -239,8 +242,10 @@
             refreshResults();
           }
         } else if (e.target.classList.contains('name') && item.type === 'file') {
+          sideContent.classList.remove('fade-in');
           sideContent.innerHTML = `<h3>${item.name}</h3><div>${parseMarkdown(item.description || '')}</div>`;
-          sidePanel.style.display = 'block';
+          void sideContent.offsetWidth;
+          sideContent.classList.add('fade-in');
         } else if (e.target.classList.contains('name') && item.type === 'dir') {
           dirStack.push(currentDir);
           currentDir = item;


### PR DESCRIPTION
## Summary
- keep side panel visible at all times
- hide close button and update layout spacing
- add fade‑in animation for side panel text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68481aa7ad248331a55cab93260c79fe