### PR TITLE
Fix extra line breaks in description display

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
         overflow-y: auto;
       }
       #side-content {
-        white-space: pre-wrap;
+        white-space: normal;
       }
       #side-panel h3 {
         margin-top: 0;
@@ -275,7 +275,9 @@
           const temp = document.createElement('div');
           temp.innerHTML = parseMarkdown(item.description || '');
           const plain = temp.textContent || '';
+          descEl.style.whiteSpace = 'pre-wrap';
           typeText(descEl, plain, 2000, () => {
+            descEl.style.whiteSpace = 'normal';
             descEl.innerHTML = parseMarkdown(item.description || '');
           });
         } else if (e.target.classList.contains('name') && item.type === 'dir') {


### PR DESCRIPTION
## Summary
- avoid `pre-wrap` mode when final text is shown
- reset whitespace style after animation to prevent extra line breaks

## Testing
- `node -c index.html` *(fails: Unknown file extension)*

------
https://chatgpt.com/codex/tasks/task_e_68482377efa083319719a0615b9deb55