### PR TITLE
Persist Datanet data on the server

### DIFF
--- a/database.json
+++ b/database.json
@@ -1,16 +1,21 @@
 {
-  "entries": [
+  "name": "root",
+  "type": "dir",
+  "children": [
     {
       "name": "Alpha Centauri",
-      "description": "Nearest star system to Sol."
+      "description": "Nearest star system to Sol.",
+      "type": "file"
     },
     {
       "name": "Galactic Archives",
-      "description": "Central repository of historical records."
+      "description": "Central repository of historical records.",
+      "type": "file"
     },
     {
       "name": "Exoplanet Survey",
-      "description": "Catalog of habitable worlds discovered to date."
+      "description": "Catalog of habitable worlds discovered to date.",
+      "type": "file"
     }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
       <div id="side-content"></div>
     </div>
     <script>
-      let fsData = JSON.parse(localStorage.getItem('fsData') || '{"name":"root","type":"dir","children":[]}');
+      let fsData = { name: 'root', type: 'dir', children: [] };
       let currentDir = fsData;
       const dirStack = [];
       const resultsDiv = document.getElementById('results');
@@ -146,28 +146,26 @@
 
 
       function saveData() {
-        localStorage.setItem('fsData', JSON.stringify(fsData));
+        fetch('/api/data', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(fsData)
+        });
       }
 
       const searchInput = document.getElementById('search');
 
-      if (fsData.children.length === 0) {
-        fetch('database.json')
-          .then(res => res.json())
-          .then(json => {
-            const entries = json.entries || [];
-            fsData.children = entries.map(item => ({ ...item, type: 'file' }));
-            saveData();
-            renderFileList();
-            refreshResults();
-          })
-          .catch(() => {
-            resultsDiv.innerHTML = '<p>Error loading database.</p>';
-          });
-      } else {
-        renderFileList();
-        refreshResults();
-      }
+      fetch('/api/data')
+        .then(res => res.json())
+        .then(json => {
+          fsData = json || { name: 'root', type: 'dir', children: [] };
+          currentDir = fsData;
+          renderFileList();
+          refreshResults();
+        })
+        .catch(() => {
+          resultsDiv.innerHTML = '<p>Error loading database.</p>';
+        });
 
       let currentSearchResults = [];
 

--- a/manage.js
+++ b/manage.js
@@ -5,7 +5,7 @@ const DB_FILE = path.join(__dirname, 'database.json');
 
 function loadDB() {
   if (!fs.existsSync(DB_FILE)) {
-    return { entries: [] };
+    return { name: 'root', type: 'dir', children: [] };
   }
   return JSON.parse(fs.readFileSync(DB_FILE, 'utf8'));
 }
@@ -35,7 +35,7 @@ switch (cmd) {
       process.exit(1);
     }
     const db = loadDB();
-    db.entries.push({ name, description });
+    db.children.push({ name, description, type: 'file' });
     saveDB(db);
     console.log('Entry added.');
     break;
@@ -49,11 +49,11 @@ switch (cmd) {
       process.exit(1);
     }
     const db = loadDB();
-    if (!db.entries[index]) {
+    if (!db.children[index]) {
       console.error('Invalid index');
       process.exit(1);
     }
-    db.entries[index] = { name, description };
+    db.children[index] = { name, description, type: 'file' };
     saveDB(db);
     console.log('Entry updated.');
     break;
@@ -65,11 +65,11 @@ switch (cmd) {
       process.exit(1);
     }
     const db = loadDB();
-    if (!db.entries[index]) {
+    if (!db.children[index]) {
       console.error('Invalid index');
       process.exit(1);
     }
-    db.entries.splice(index, 1);
+    db.children.splice(index, 1);
     saveDB(db);
     console.log('Entry removed.');
     break;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "datanet",
+  "version": "1.0.0",
+  "description": "Datanet interface",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const DB_FILE = path.join(__dirname, 'database.json');
+
+app.use(express.json());
+app.use(express.static(__dirname));
+
+function loadDB() {
+  if (!fs.existsSync(DB_FILE)) {
+    return { name: 'root', type: 'dir', children: [] };
+  }
+  return JSON.parse(fs.readFileSync(DB_FILE, 'utf8'));
+}
+
+function saveDB(data) {
+  fs.writeFileSync(DB_FILE, JSON.stringify(data, null, 2));
+}
+
+app.get('/api/data', (req, res) => {
+  res.json(loadDB());
+});
+
+app.post('/api/data', (req, res) => {
+  saveDB(req.body);
+  res.json({ status: 'ok' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- move Datanet storage out of localStorage
- add simple Express server with API for storing data
- restructure `database.json` to hold the virtual file system
- update CLI tool to handle new format
- add `package.json`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848283448448331b9a6dd1c1baf8ef7