### PR TITLE
Move API to Netlify Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Datanet
+
+This project displays data from a Notion database. It can be deployed to Netlify using serverless functions.
+
+## Deploying to Netlify
+
+1. Create a new site in Netlify and link this repository.
+2. In the site settings, add two environment variables:
+   - `NOTION_API_KEY` – your Notion integration token.
+   - `DATABASE_ID` – the ID of the database to query.
+3. The provided `netlify.toml` routes `/database` and `/page/:id` requests to serverless functions located in `netlify/functions`.
+4. Push your code and Netlify will build and deploy the site automatically.
+
+During local development you can run the functions with [Netlify CLI](https://docs.netlify.com/cli/get-started/):
+
+```bash
+npm install -g netlify-cli
+netlify dev
+```

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
 
       const searchInput = document.getElementById('search');
 
-      fetch('database.json')
+      fetch('/database')
         .then(res => res.json())
         .then(json => {
           fsData = json || { name: 'root', type: 'dir', children: [] };

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,13 @@
+[build]
+  publish = "."
+  functions = "netlify/functions"
+
+[[redirects]]
+  from = "/database"
+  to = "/.netlify/functions/database"
+  status = 200
+
+[[redirects]]
+  from = "/page/*"
+  to = "/.netlify/functions/page/:splat"
+  status = 200

--- a/netlify/functions/database.js
+++ b/netlify/functions/database.js
@@ -1,0 +1,21 @@
+const { Client } = require('@notionhq/client');
+
+exports.handler = async function(event, context) {
+  const notion = new Client({ auth: process.env.NOTION_API_KEY });
+  const databaseId = process.env.DATABASE_ID;
+  if (!databaseId || !process.env.NOTION_API_KEY) {
+    return { statusCode: 500, body: 'Missing Notion credentials' };
+  }
+
+  try {
+    const response = await notion.databases.query({ database_id: databaseId });
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(response.results)
+    };
+  } catch (error) {
+    console.error(error);
+    return { statusCode: 500, body: 'Error fetching database' };
+  }
+};

--- a/netlify/functions/page.js
+++ b/netlify/functions/page.js
@@ -1,0 +1,21 @@
+const { Client } = require('@notionhq/client');
+
+exports.handler = async function(event, context) {
+  const notion = new Client({ auth: process.env.NOTION_API_KEY });
+  const id = event.path.split('/').pop();
+  if (!id) {
+    return { statusCode: 400, body: 'Missing page id' };
+  }
+
+  try {
+    const response = await notion.pages.retrieve({ page_id: id });
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(response)
+    };
+  } catch (error) {
+    console.error(error);
+    return { statusCode: 500, body: 'Error fetching page' };
+  }
+};

--- a/package.json
+++ b/package.json
@@ -2,12 +2,11 @@
   "name": "datanet",
   "version": "1.0.0",
   "description": "Datanet interface",
-  "main": "server.js",
   "scripts": {
-    "start": "node server.js",
+    "start": "netlify dev",
     "test": "echo \"No tests specified\""
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "@notionhq/client": "^2.2.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,9 +1,0 @@
-const express = require('express');
-const app = express();
-const PORT = process.env.PORT || 3000;
-
-app.use(express.static(__dirname));
-
-app.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
-});


### PR DESCRIPTION
## Summary
- use Netlify Functions for `/database` and `/page/:id`
- configure redirects in `netlify.toml`
- load database via new endpoint in `index.html`
- document Netlify deployment
- remove unused Express server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d63ff720c833198f69ec77fcc7b2e