### PR TITLE
Display Notion page content

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,7 +169,7 @@
             const html = parseMarkdown(md);
             const descEl = document.getElementById('desc');
             descEl.style.whiteSpace = 'normal';
-            descEl.innerHTML = html;
+            typeText(descEl, html, 1000, true);
           })
           .catch(() => {
             const descEl = document.getElementById('desc');

--- a/index.html
+++ b/index.html
@@ -136,13 +136,45 @@
         return html;
       }
 
+      function blocksToMarkdown(blocks) {
+        const getText = rich =>
+          (rich || []).map(r => r.plain_text).join('');
+        return (blocks || [])
+          .map(block => {
+            switch (block.type) {
+              case 'heading_1':
+                return '# ' + getText(block.heading_1.rich_text);
+              case 'heading_2':
+                return '## ' + getText(block.heading_2.rich_text);
+              case 'heading_3':
+                return '### ' + getText(block.heading_3.rich_text);
+              case 'bulleted_list_item':
+                return '- ' + getText(block.bulleted_list_item.rich_text);
+              case 'numbered_list_item':
+                return '1. ' + getText(block.numbered_list_item.rich_text);
+              default:
+                return getText(block[block.type]?.rich_text || []);
+            }
+          })
+          .join('\n');
+      }
+
       function openFile(item) {
-        sideContent.innerHTML = `<h3>${item.name}</h3><div id="desc"></div>`;
+        sideContent.innerHTML = `<h3>${item.name}</h3><div id="desc">Loading...</div>`;
         sidePanel.scrollTop = 0;
-        const descEl = document.getElementById('desc');
-        const html = parseMarkdown(item.description || '');
-        descEl.style.whiteSpace = 'normal';
-        typeText(descEl, html, 1000, true);
+        fetch(`/page/${item.id}`)
+          .then(res => res.json())
+          .then(blocks => {
+            const md = blocksToMarkdown(blocks);
+            const html = parseMarkdown(md);
+            const descEl = document.getElementById('desc');
+            descEl.style.whiteSpace = 'normal';
+            descEl.innerHTML = html;
+          })
+          .catch(() => {
+            const descEl = document.getElementById('desc');
+            descEl.textContent = 'Error loading page';
+          });
       }
 
 

--- a/netlify/functions/page.js
+++ b/netlify/functions/page.js
@@ -8,11 +8,11 @@ exports.handler = async function(event, context) {
   }
 
   try {
-    const response = await notion.pages.retrieve({ page_id: id });
+    const response = await notion.blocks.children.list({ block_id: id, page_size: 100 });
     return {
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(response)
+      body: JSON.stringify(response.results)
     };
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
## Summary
- fetch page blocks using Netlify function `page.js`
- convert blocks to markdown on the frontend
- load page contents when a result is clicked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d68febcdc8331bbf48a751feef57f