### PR TITLE
Display Notion entry type

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,8 +32,9 @@
       }
       #results { margin-top: 20px; }
       #toolbar { margin-top: 20px; }
-      #file-list { list-style: none; padding-left: 0; margin-top: 10px; }
-      #file-list li { display: flex; align-items: center; padding: 4px 0; }
+#file-list { list-style: none; padding-left: 0; margin-top: 10px; }
+#file-list li { display: flex; align-items: center; padding: 4px 0; }
+#file-list li.category { font-weight: bold; margin-top: 10px; }
       #file-list li .icon { width: 20px; }
       #file-list li .name { flex: 1; cursor: pointer; }
       #side-panel {
@@ -273,13 +274,28 @@
           fileList.innerHTML = '<li>No items.</li>';
           return;
         }
-        fileList.innerHTML = children
-          .map(
-            (item, index) =>
-              `<li><span class="icon">&gt;</span>` +
-              `<span class="name" data-index="${index}">${item.name}</span></li>`
-          )
+
+        const groups = {};
+        children.forEach((item, index) => {
+          const type = item.entryType || 'Uncategorized';
+          if (!groups[type]) groups[type] = [];
+          groups[type].push({ item, index });
+        });
+
+        const html = Object.keys(groups)
+          .sort()
+          .map(type => {
+            const items = groups[type]
+              .map(
+                ({ item, index }) =>
+                  `<li><span class="icon">&gt;</span>` +
+                  `<span class="name" data-index="${index}">${item.name}</span></li>`
+              )
+              .join('');
+            return `<li class="category">${type}</li>` + items;
+          })
           .join('');
+        fileList.innerHTML = html;
       }
 
 

--- a/index.html
+++ b/index.html
@@ -160,7 +160,8 @@
       }
 
       function openFile(item) {
-        sideContent.innerHTML = `<h3>${item.name}</h3><div id="desc">Loading...</div>`;
+        const typeInfo = item.entryType ? `<p>${item.entryType}</p>` : '';
+        sideContent.innerHTML = `<h3>${item.name}</h3>${typeInfo}<div id="desc">Loading...</div>`;
         sidePanel.scrollTop = 0;
         fetch(`/page/${item.id}`)
           .then(res => res.json())
@@ -195,6 +196,7 @@
                     page?.properties?.Name?.title?.[0]?.plain_text ||
                     'Untitled',
                   type: 'file',
+                  entryType: page?.properties?.Type?.select?.name || '',
                   description: ''
                 }))
                 .sort((a, b) => a.name.localeCompare(b.name))


### PR DESCRIPTION
## Summary
- show the Notion `Type` for each page
- include the type information when building the file list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ed89f01108331ac011096f5afcbcf